### PR TITLE
UnrealEngine Runtime Projects Output To Managed Folder

### DIFF
--- a/UnrealEngine.Runtime/Loader/Loader.csproj
+++ b/UnrealEngine.Runtime/Loader/Loader.csproj
@@ -17,7 +17,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <!--<OutputPath>bin\Debug\</OutputPath>-->
+    <OutputPath>..\..\USharp\Binaries\Managed\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
+++ b/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
@@ -16,7 +16,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <!--<OutputPath>bin\Debug\</OutputPath>-->
+    <OutputPath>..\..\USharp\Binaries\Managed\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
+++ b/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/UnrealEngine.AssemblyRewriter.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <!--<OutputPath>bin\Debug\</OutputPath>-->
-    <OutputPath>..\..\USharp\Binaries\Managed\</OutputPath>
+    <OutputPath>..\..\USharp\Binaries\Managed\AssemblyRewriter\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
+++ b/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
@@ -16,7 +16,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <!--<OutputPath>bin\Debug\</OutputPath>-->
+    <OutputPath>..\..\USharp\Binaries\Managed\</OutputPath>
     <DefineConstants>TRACE;DEBUG;WITH_EDITORONLY_DATA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
This fixes the C# Loader Error when Loading a Project after enabling the Plugin.