### PR TITLE
Fixed CompileCS Method By Using Visual Studio MSBuild Exe

### DIFF
--- a/Managed/PluginInstaller/PluginInstaller/Program.cs
+++ b/Managed/PluginInstaller/PluginInstaller/Program.cs
@@ -438,6 +438,26 @@ namespace PluginInstaller
         {
             try
             {
+                string baseMicrosoftKeyPath = @"SOFTWARE\WOW6432Node\Microsoft";
+                string visualStudioRegistryKeyPath = baseMicrosoftKeyPath + @"\VisualStudio\SxS\VS7";
+
+                //Try Obtaining the VS version of MSBuild First
+                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(visualStudioRegistryKeyPath))
+                {
+                    if (key != null)
+                    {
+                        string path = key.GetValue("15.0") as string;
+                        if (!string.IsNullOrEmpty(path))
+                        {
+                            path = Path.Combine(path, "MSBuild", "15.0", "Bin", "msbuild.exe");
+                            if (File.Exists(path))
+                            {
+                                return path;
+                            }
+                        }
+                    }
+                }
+
                 using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\MSBUILD\ToolsVersions\4.0"))
                 {
                     string path = key.GetValue("MSBuildToolsPath") as string;


### PR DESCRIPTION
This fix will only work if the user has visual studio 2017 installed, and the registry's are properly set up. I didn't bother testing the old registry's because microsoft seems to update them frequently. I'd recommend opening up Registry Editor and looking up the appropriate paths if this step fails. I used https://developercommunity.visualstudio.com/content/problem/2813/cant-find-registry-entries-for-visual-studio-2017.html as a reference.