### PR TITLE
Adds UE4 Runtime References To Generated Modules Projects

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeGeneratorSettings.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeGeneratorSettings.cs
@@ -291,7 +291,7 @@ namespace UnrealEngine.Runtime
         public CodeGeneratorSettings()
         {
             GameProjMerge = new ManagedGameProjMerge();
-            EngineProjMerge = new ManagedEngineProjMerge();
+            EngineProjMerge = ManagedEngineProjMerge.EngineAndPluginsCombined;
             Prefixes = new TypePrefixes();
             Namespaces = new ManagedNamespaces();
             FolderEmulation = new ManagedFolderEmulation();

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
@@ -54,7 +54,7 @@ namespace UnrealEngine.Runtime
                 try
                 {
                     CreateFileDirectoryIfNotExists(projPath);
-                    File.WriteAllText(projPath, GetProjectFileContents(dte.Version, Path.GetFileNameWithoutExtension(projPath)));
+                    File.WriteAllText(projPath, GetProjectFileContents(dte.Version, Path.GetFileNameWithoutExtension(projPath), GetEnginePathFromCurrentFolder(projPath) != null));
                 }
                 catch
                 {
@@ -310,13 +310,13 @@ namespace UnrealEngine.Runtime
             return false;
         }
 
-        private string GetProjectFileContents(string version, string projectName)
+        private string GetProjectFileContents(string version, string projectName, bool insideEngine)
         {
             string _ue4RuntimePath = Settings.EngineProjMerge ==
                 CodeGeneratorSettings.ManagedEngineProjMerge.EngineAndPluginsCombined ?
                 @"..\UnrealEngine.Runtime.dll" : @"..\..\..\UnrealEngine.Runtime.dll";
             Guid projectGuid = Guid.NewGuid();
-            return @"<?xml version=""1.0"" encoding=""utf-8""?>
+            string _fileContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""" + version + @""" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
   <PropertyGroup>
@@ -330,14 +330,52 @@ namespace UnrealEngine.Runtime
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
+  </ItemGroup>";
+            if (insideEngine)
+            {
+                _fileContents +=
+  @"<ItemGroup>
     <Reference Include=""" + "UnrealEngine.Runtime" + @""">
-      <HintPath>"+_ue4RuntimePath+@"</HintPath>
+      <HintPath>" + _ue4RuntimePath + @"</HintPath>
     </Reference>
-  </ItemGroup>
-  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+  </ItemGroup>";
+            }
+            _fileContents +=
+  @"<Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>";
+            return _fileContents;
+        }
+
+        string GetEnginePathFromCurrentFolder(string currentPath)
+        {
+            // Check upwards for /Epic Games/ENGINE_VERSION/Engine/Plugins/USharp/ and extract the path from there
+            string[] parentFolders = { "Modules", "Managed", "Binaries", "USharp", "Plugins", "Engine" };
+            //string currentPath = GetCurrentDirectory();
+
+            DirectoryInfo dir = Directory.GetParent(currentPath);
+            if(Settings.EngineProjMerge != CodeGeneratorSettings.ManagedEngineProjMerge.EngineAndPluginsCombined)
+            {
+                //Directory Starts To Level Up If Merge Settings Isn't
+                //Combining Engine and Plugins
+                dir = dir.Parent;
+                dir = dir.Parent;
+            }
+            for (int i = 0; i < parentFolders.Length; i++)
+            {
+                if (!dir.Exists || !dir.Name.Equals(parentFolders[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+                dir = dir.Parent;
+            }
+
+            // Make sure one of these folders exists along side the Engine folder: FeaturePacks, Samples, Templates
+            if (dir.Exists && Directory.Exists(Path.Combine(dir.FullName, "Templates")))
+            {
+                return dir.FullName;
+            }
+
+            return null;
         }
 
         /** Return codes when trying to access an existing VS instance */

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
@@ -310,8 +310,11 @@ namespace UnrealEngine.Runtime
             return false;
         }
 
-        private static string GetProjectFileContents(string version, string projectName)
+        private string GetProjectFileContents(string version, string projectName)
         {
+            string _ue4RuntimePath = Settings.EngineProjMerge ==
+                CodeGeneratorSettings.ManagedEngineProjMerge.EngineAndPluginsCombined ?
+                @"..\UnrealEngine.Runtime.dll" : @"..\..\..\UnrealEngine.Runtime.dll";
             Guid projectGuid = Guid.NewGuid();
             return @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""" + version + @""" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
@@ -327,6 +330,11 @@ namespace UnrealEngine.Runtime
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include=""" + "UnrealEngine.Runtime" + @""">
+      <HintPath>"+_ue4RuntimePath+@"</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>";

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
@@ -327,7 +327,8 @@ namespace UnrealEngine.Runtime
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <RootNamespace>" + projectName + @"</RootNamespace>
     <AssemblyName>" + projectName + @"</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>";


### PR DESCRIPTION
This reduces the number of errors caused by the unreal runtime project not being referenced by the generated projects. I also made EngineProjMerge setting default to EngineAndPluginsCombined.