### PR TITLE
Removes Engine Check GetProjectFileContents Method

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/CodeManagers/VisualStudioCodeManager.cs
@@ -332,15 +332,12 @@ namespace UnrealEngine.Runtime
   </PropertyGroup>
   <ItemGroup>
   </ItemGroup>";
-            if (insideEngine)
-            {
-                _fileContents +=
-  @"<ItemGroup>
+            _fileContents +=
+@"<ItemGroup>
     <Reference Include=""" + "UnrealEngine.Runtime" + @""">
       <HintPath>" + _ue4RuntimePath + @"</HintPath>
     </Reference>
   </ItemGroup>";
-            }
             _fileContents +=
   @"<Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>";


### PR DESCRIPTION
This'll allow users who installed USharp to their game plugins folder to have the UnrealEngine.Runtime reference in their generated solution projects.