### PR TITLE
fix #16 adding an auto generated managed game solution when plugin loads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,3 +333,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+Binaries

--- a/Managed/UnrealEngine.Runtime/.editorconfig
+++ b/Managed/UnrealEngine.Runtime/.editorconfig
@@ -1,0 +1,117 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+# Code files 
+[*.{cs,csx,vb,vbx}] 
+indent_size = 4 
+insert_final_newline = true 
+charset = utf-8-bom 
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = false:silent 
+dotnet_style_qualification_for_property = false:silent 
+dotnet_style_qualification_for_method = false:silent 
+dotnet_style_qualification_for_event = false:silent 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = true:silent 
+csharp_style_var_when_type_is_apparent = true:silent 
+csharp_style_var_elsewhere = true:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/AssemblyRewriter.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/AssemblyRewriter.cs
@@ -24,7 +24,7 @@ namespace UnrealEngine.Runtime
 
     partial class AssemblyRewriter
     {
-        public const bool UpdatePdb = false;
+        public const bool UpdatePdb = true;
 
         // These collections are only the available types which need updating, additional lookups required for other types
         Dictionary<TypeDefinition, ManagedUnrealTypeInfo> classesByType = new Dictionary<TypeDefinition, ManagedUnrealTypeInfo>();
@@ -157,6 +157,11 @@ namespace UnrealEngine.Runtime
 
             ReaderParameters readerParams = new ReaderParameters();
             WriterParameters writerParams = new WriterParameters();
+
+            var resolver = readerParams.AssemblyResolver as DefaultAssemblyResolver ?? new DefaultAssemblyResolver();
+            readerParams.AssemblyResolver = resolver;
+
+            resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
 
             if (File.Exists(pdbFile) && UpdatePdb)
             {

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/AssemblyRewriter.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/AssemblyRewriter.cs
@@ -24,7 +24,7 @@ namespace UnrealEngine.Runtime
 
     partial class AssemblyRewriter
     {
-        public const bool UpdatePdb = true;
+        public const bool UpdatePdb = false;
 
         // These collections are only the available types which need updating, additional lookups required for other types
         Dictionary<TypeDefinition, ManagedUnrealTypeInfo> classesByType = new Dictionary<TypeDefinition, ManagedUnrealTypeInfo>();

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/Program.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/Program.cs
@@ -16,12 +16,13 @@ namespace UnrealEngine.Runtime
 
         public static void Main(string[] args)
         {
-	        if (!args.Any()){
-		        Console.Error.WriteLine($"Error: No input files. Add file path to dll as argument.");
-		        Environment.Exit(2);
-	        }
-	        
-	        Stopwatch stopwatch = new Stopwatch();
+            if (!args.Any())
+            {
+                Console.Error.WriteLine($"Error: No input files. Add file path to dll as argument.");
+                Environment.Exit(2);
+            }
+        
+            Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
             UnrealTypes.Load();
@@ -32,19 +33,19 @@ namespace UnrealEngine.Runtime
                 ManagedUnrealReflectionBase.UpdateSerializerCode();
                 //RunTests(rewriter);
             }
-	        
+
 
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
-	        Console.WriteLine($"Processing file:");
+            Console.WriteLine($"Processing file:");
 
             foreach (string filePath in args)
             {
-	            Console.WriteLine($"Processing file: {filePath}");
-	            var success = ProcessAssembly(rewriter, filePath);
-	            if (!success) 
-				{
-		            Environment.ExitCode = 3;
-	            }
+                Console.WriteLine($"Processing file: {filePath}");
+                var success = ProcessAssembly(rewriter, filePath);
+                if (!success)
+                {
+                    Environment.ExitCode = 3;
+                }
                 additionalAssemblySearchPath = null;
             }
 
@@ -109,41 +110,45 @@ namespace UnrealEngine.Runtime
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
                 ManagedUnrealModuleInfo moduleInfo = null;
-	            try {
-		            Debugger.Launch();
-		            moduleInfo = ManagedUnrealModuleInfo.CreateModuleFromAssembly(assembly);
-	            } catch (Exception e) {
-		            Console.WriteLine("Error while parsing module \"" + assembly.GetName().Name + "\"");
-		            Console.WriteLine();
-		            Console.WriteLine(e.Message);
-		            Console.WriteLine();
-		            Console.WriteLine(e.ToString());
-	            }
-	            
-	            stopwatch.Stop();
-	            Console.WriteLine("Read \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+                try 
+                {
+                    moduleInfo = ManagedUnrealModuleInfo.CreateModuleFromAssembly(assembly);
+                } catch (Exception e) 
+                {
+                    Console.WriteLine("Error while parsing module \"" + assembly.GetName().Name + "\"");
+                    Console.WriteLine();
+                    Console.WriteLine(e.Message);
+                    Console.WriteLine();
+                    Console.WriteLine(e.ToString());
+                }
+                
+                stopwatch.Stop();
+                Console.WriteLine("Read \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
 
                 if (moduleInfo != null)
                 {
                     stopwatch.Reset();
                     stopwatch.Start();
 
-	                var noError = true;
+                    var noError = true;
 
-	                try {
-		                rewriter.RewriteModule(moduleInfo, filePath);
-		                Console.WriteLine("Write \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
-	                } catch (Exception e) {
-		                Console.WriteLine("Error when rewriting module \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
-		                Console.WriteLine();
-		                Console.WriteLine(e.Message);
-		                Console.WriteLine();
-		                Console.WriteLine(e.ToString());
-		                noError = false;
-	                } finally {
-		                stopwatch.Stop();
-	                }
-					
+                    try 
+                    {
+                        rewriter.RewriteModule(moduleInfo, filePath);
+                        Console.WriteLine("Write \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+                    } catch (Exception e) 
+                    {
+                        Console.WriteLine("Error when rewriting module \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+                        Console.WriteLine();
+                        Console.WriteLine(e.Message);
+                        Console.WriteLine();
+                        Console.WriteLine(e.ToString());
+                        noError = false;
+                    } finally 
+                    {
+                        stopwatch.Stop();
+                    }
+                    
                     return noError;
                 }
             }

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/Program.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.AssemblyRewriter/Program.cs
@@ -13,7 +13,12 @@ namespace UnrealEngine.Runtime
     {
         public static void Main(string[] args)
         {
-            Stopwatch stopwatch = new Stopwatch();
+	        if (!args.Any()){
+		        Console.Error.WriteLine($"Error: No input files. Add file path to dll as argument.");
+		        Environment.Exit(2);
+	        }
+	        
+	        Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
             UnrealTypes.Load();
@@ -24,10 +29,16 @@ namespace UnrealEngine.Runtime
                 ManagedUnrealReflectionBase.UpdateSerializerCode();
                 //RunTests(rewriter);
             }
+	        
 
-            foreach (string filePath in args)
-            {
-                ProcessAssembly(rewriter, filePath);
+	        Console.WriteLine($"Processing file:");
+
+            foreach (string filePath in args) {
+	            Console.WriteLine($"Processing file: {filePath}");
+	            var success = ProcessAssembly(rewriter, filePath);
+	            if (!success) {
+		            Environment.ExitCode = 3;
+	            }
             }
 
             stopwatch.Stop();
@@ -79,42 +90,42 @@ namespace UnrealEngine.Runtime
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
                 ManagedUnrealModuleInfo moduleInfo = null;
-                try
-                {
-                    moduleInfo = ManagedUnrealModuleInfo.CreateModuleFromAssembly(assembly);
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine("Error when parsing module \"" + assembly.GetName().Name + "\"");
-                    Console.WriteLine();
-                    Console.WriteLine(e.Message);
-                    Console.WriteLine();
-                    Console.WriteLine(e.ToString());
-                }
-                stopwatch.Stop();
-                Console.WriteLine("Read \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+	            try {
+		            Debugger.Launch();
+		            moduleInfo = ManagedUnrealModuleInfo.CreateModuleFromAssembly(assembly);
+	            } catch (Exception e) {
+		            Console.WriteLine("Error while parsing module \"" + assembly.GetName().Name + "\"");
+		            Console.WriteLine();
+		            Console.WriteLine(e.Message);
+		            Console.WriteLine();
+		            Console.WriteLine(e.ToString());
+	            }
+	            
+	            stopwatch.Stop();
+	            Console.WriteLine("Read \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
 
                 if (moduleInfo != null)
                 {
                     stopwatch.Reset();
                     stopwatch.Start();
 
-                    try
-                    {
-                        rewriter.RewriteModule(moduleInfo, filePath);
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine("Error when rewriting module \"" + assembly.GetName().Name + "\"");
-                        Console.WriteLine();
-                        Console.WriteLine(e.Message);
-                        Console.WriteLine();
-                        Console.WriteLine(e.ToString());
-                    }
+	                var noError = true;
 
-                    stopwatch.Stop();
-                    Console.WriteLine("Write \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
-                    return true;
+	                try {
+		                rewriter.RewriteModule(moduleInfo, filePath);
+		                Console.WriteLine("Write \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+	                } catch (Exception e) {
+		                Console.WriteLine("Error when rewriting module \"" + assembly.GetName().Name + "\" " + stopwatch.Elapsed);
+		                Console.WriteLine();
+		                Console.WriteLine(e.Message);
+		                Console.WriteLine();
+		                Console.WriteLine(e.ToString());
+		                noError = false;
+	                } finally {
+		                stopwatch.Stop();
+	                }
+					
+                    return noError;
                 }
             }
             return false;

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime.sln
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnrealEngine.Runtime", "UnrealEngine.Runtime\UnrealEngine.Runtime.csproj", "{61FD3B78-387B-4B61-A9DA-FCC5B9B80E5B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnrealEngine.AssemblyRewriter", "UnrealEngine.AssemblyRewriter\UnrealEngine.AssemblyRewriter.csproj", "{CBD90449-5FE1-4366-A6D1-14B05F3FBA0D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Loader", "Loader\Loader.csproj", "{C284889D-AA3A-4EC1-B4EA-FAA4A3A92C33}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F98E80EC-0F91-42F0-9E1D-0FE57BDC924A}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,5 +34,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E3B49CA2-52F1-46DB-87F1-4D9A01AEF990}
 	EndGlobalSection
 EndGlobal

--- a/ManagedGameSolutionTemplate/Directory.Build.props
+++ b/ManagedGameSolutionTemplate/Directory.Build.props
@@ -1,0 +1,9 @@
+<!--
+    MSBuild special user file which defines the props which should be used by any project. 
+    It is picked up by msbuild itself
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectSetup.props" />
+
+  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectSetup.targets" />
+</Project>

--- a/ManagedGameSolutionTemplate/GameCode/GameCode.csproj
+++ b/ManagedGameSolutionTemplate/GameCode/GameCode.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <!--This should and can not be added to the props file-->
+  <PropertyGroup>
+    <!--
+    <TargetFramework>netstandard2.0</TargetFramework>
+    -->
+    <TargetFramework>net4.5.2</TargetFramework>
+  </PropertyGroup>
+
+  <!--This should and can not be added to the props file-->
+  <PropertyGroup>
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+</Project>

--- a/ManagedGameSolutionTemplate/GameCode/GameCode.csproj
+++ b/ManagedGameSolutionTemplate/GameCode/GameCode.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <!--This should and can not be added to the props file-->
   <PropertyGroup>
-    <!--
     <TargetFramework>netstandard2.0</TargetFramework>
-    -->
-    <TargetFramework>net4.5.2</TargetFramework>
   </PropertyGroup>
 
   <!--This should and can not be added to the props file-->
+  <!--ISSUE like described here https://github.com/Fody/Costura/issues/235 -->
   <PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
     <OutputPath>$(OutDir)</OutputPath>
   </PropertyGroup>
 </Project>

--- a/ManagedGameSolutionTemplate/GameCode/Test.cs
+++ b/ManagedGameSolutionTemplate/GameCode/Test.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnrealEngine.Runtime;
+
+namespace HelloUSharp
+{
+    [UClass, Blueprintable, BlueprintType]
+    public class HelloUFromUSharp : UObject
+    {
+        [UProperty, EditAnywhere, BlueprintReadWrite]
+        public int Value123 { get; set; }
+
+        [UProperty, EditAnywhere, BlueprintReadWrite, Category("MyCategory")]
+        public string Value456 { get; set; }
+
+        [UProperty(PropFlags.BlueprintCallable | PropFlags.BlueprintAssignable), EditAnywhere, BlueprintReadWrite]
+        public HelloUSharpDelegate DelegateTest { get; set; }
+
+        [UFunction, BlueprintCallable]
+        public void CallMe(string arg1)
+        {
+            FMessage.Log("Hello from CallMe: " + arg1);
+        }
+    }
+
+    public class HelloUSharpDelegate : FMulticastDelegate<HelloUSharpDelegate.Signature>
+    {
+        public delegate void Signature(byte param1, string param2, int param3);
+    }
+}

--- a/ManagedGameSolutionTemplate/ManagedGameCode.sln
+++ b/ManagedGameSolutionTemplate/ManagedGameCode.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GameCode", "GameCode\GameCode.csproj", "{9F8F236E-3049-4F68-A967-6E995101CF1A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9F8F236E-3049-4F68-A967-6E995101CF1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F8F236E-3049-4F68-A967-6E995101CF1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F8F236E-3049-4F68-A967-6E995101CF1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F8F236E-3049-4F68-A967-6E995101CF1A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7912279E-B1D8-49FB-B65E-A15A60B44E3A}
+	EndGlobalSection
+EndGlobal

--- a/ManagedGameSolutionTemplate/Readme.md
+++ b/ManagedGameSolutionTemplate/Readme.md
@@ -1,0 +1,6 @@
+The template uses SDK style MSBUILD projects.
+The file 'USharp.ProjectGeneratedVariables.props' is populated with installation and project specific variables. It should be ignored in SCM since it will change depending on user, project and engine installation.
+
+Possible Improvements.
+* Move the sln copy and props file population code to c#
+* Use a populated ProjectGeneratedVariables.props file from the intermediate directory which is ignored as an Unreal default in SCM's

--- a/ManagedGameSolutionTemplate/USharp.ProjectGeneratedVariables.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectGeneratedVariables.props
@@ -1,6 +1,12 @@
+<!--GENERATED. 
+    Do not modify. Modifications will be lost.
+    This file should be ignored in any SCM (i.e. Git or SVN)
+-->
+<!--This file is modifyed by the plugin whenit is loading by the editor-->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UE4Defines>#Constants#</UE4Defines>
+    <USharpPluginPath>#PluginPath#</USharpPluginPath>
     <UE4GamePath>#GamePath#</UE4GamePath>
     <UE4GameName>#GameName#</UE4GameName>
   </PropertyGroup>

--- a/ManagedGameSolutionTemplate/USharp.ProjectGeneratedVariables.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectGeneratedVariables.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <UE4Defines>#Constants#</UE4Defines>
+    <UE4GamePath>#GamePath#</UE4GamePath>
+    <UE4GameName>#GameName#</UE4GameName>
+  </PropertyGroup>
+</Project>

--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
@@ -1,0 +1,29 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectGeneratedVariables.props" />
+
+  <PropertyGroup>
+    <USharpPluginPath>$(MSBuildStartupDirectory)/../Plugins/USharp</USharpPluginPath>
+  </PropertyGroup>
+
+
+  <!--for dev purpose only. it allows to inspect the settings in the template .sln/.csprj-->
+  <Choose>
+    <When Condition="!Exists('$(USharpPluginPath)')">
+      <PropertyGroup>
+        <USharpPluginPath>$(MSBuildStartupDirectory)/../../USharp</USharpPluginPath>
+      </PropertyGroup>
+    </When>
+  </Choose>
+  <!--end-->
+
+
+  <PropertyGroup>
+    <USharpRunntimeDllPath>$(USharpPluginPath)/Binaries/Managed/UnrealEngine.Runtime.dll</USharpRunntimeDllPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="UnrealEngine.Runtime">
+      <HintPath>$(USharpRunntimeDllPath)</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
@@ -1,12 +1,17 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectGeneratedVariables.props" />
 
-  <PropertyGroup>
-    <USharpPluginPath>$(MSBuildStartupDirectory)/../Plugins/USharp</USharpPluginPath>
-  </PropertyGroup>
+  <Choose>
+    <!--Fallback: This sets up the plugin path when it is used as a game plugin and USharpPluginPath failes to resolve. This sould only happen during development since USharpPluginPath sould always point to the correct path however we may not have ncountered all circumstances yet-->
+    <When Condition="!Exists('$(USharpPluginPath)')">
+      <PropertyGroup>
+        <USharpPluginPath>$(MSBuildStartupDirectory)/../Plugins/USharp</USharpPluginPath>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
 
-  <!--for dev purpose only. it allows to inspect the settings in the template .sln/.csprj-->
+  <!--Fallback: for dev purpose only. it allows to inspect the settings in the template .sln/.csprj-->
   <Choose>
     <When Condition="!Exists('$(USharpPluginPath)')">
       <PropertyGroup>

--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.targets
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.targets
@@ -1,0 +1,29 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- inject defines and override output path -->
+  <PropertyGroup>
+    <DefineConstants>$(UE4Defines);$(DefineConstants)</DefineConstants>
+    <OutDir>$(MSBuildStartupDirectory)\Binaries</OutDir>
+    <OutputPath>$(OutDir)</OutputPath>
+    <AssemblyName>$(UE4GameName)-Managed</AssemblyName>
+  </PropertyGroup>
+
+  <Target Name="CheckConfig" BeforeTargets="CoreCompile">
+    <Error
+      Condition="!Exists('$(USharpRunntimeDllPath)')"
+      Text="Could not find USharp Plugin Directory at '$(USharpRunntimeDllPath)'. This will lead to managed solution compile errors. (TODO: add hint what to fix)"
+    />
+  </Target>
+
+  <Target Name="AssemblyProcessing" 
+          AfterTargets="PostBuildEvent"
+    >
+    <PropertyGroup>
+        <USharpAssemblyRewriterPath>$(USharpPluginPath)/Binaries/Managed/AssemblyRewriter/UnrealEngine.AssemblyRewriter.exe</USharpAssemblyRewriterPath>
+    </PropertyGroup>
+    <Exec
+      Command="&quot;$(USharpAssemblyRewriterPath)&quot; &quot;$(OutDir)$(AssemblyName).dll&quot;"
+      IgnoreExitCode ="false" 
+    />
+  </Target>
+
+</Project>

--- a/Source/USharp/Private/CSharpLoader.h
+++ b/Source/USharp/Private/CSharpLoader.h
@@ -48,4 +48,5 @@ public:
 	bool Load(FString assemblyPath, FString customArgs, FString loaderAssemblyPath, bool loaderEnabled);
 	bool IsLoaded();
 	void LogLoaderError(FString error);
+	static FString GetPluginBinariesDir();
 };

--- a/Source/USharp/Private/CSharpProjectGeneration.cpp
+++ b/Source/USharp/Private/CSharpProjectGeneration.cpp
@@ -1,0 +1,74 @@
+#include "CSharpProjectGeneration.h"
+
+#include "USharpPCH.h"
+#include "CSharpLoader.h"
+
+#include "Core.h"
+
+FString pluginsBaseDir;
+FString managedGameSolutionTemplateDir;
+FString managedGameSolutionFinalDir;
+FString genFileFullPath;
+FString projectGeneratedVariablesFullFilePath;
+
+bool CSharpProjectGeneration::GenerateProject() {
+	//All this should only be done at edit time not in player builds
+#if WITH_EDITOR
+	pluginsBaseDir = CSharpLoader::GetPluginBinariesDir();
+
+	managedGameSolutionTemplateDir = FPaths::Combine(*pluginsBaseDir, TEXT("../") TEXT("ManagedGameSolutionTemplate"));
+	managedGameSolutionFinalDir = FPaths::Combine(FPaths::ProjectDir(), TEXT("Managed"));
+
+	managedGameSolutionTemplateDir = FPaths::ConvertRelativePathToFull(managedGameSolutionTemplateDir);
+
+	genFileFullPath = FPaths::Combine(managedGameSolutionFinalDir, TEXT(".usharpGenerated"));
+	projectGeneratedVariablesFullFilePath = FPaths::Combine(managedGameSolutionFinalDir, TEXT("USharp.ProjectGeneratedVariables.props"));
+
+	CopySolutionTemplate();
+#endif // IS_MONOLITHIC
+	return true;
+}
+
+bool CSharpProjectGeneration::CopySolutionTemplate() {
+
+	if (!FPaths::FileExists(genFileFullPath)) {
+		auto & fileManager = IFileManager::Get();
+		if (!FPaths::DirectoryExists(managedGameSolutionFinalDir)) {
+			fileManager.MakeDirectory(*managedGameSolutionFinalDir);
+		}
+		auto & platfromFileHandler = FPlatformFileManager::Get().GetPlatformFile();
+		
+		auto sucess = true;
+
+		sucess = sucess && platfromFileHandler.CopyDirectoryTree(*managedGameSolutionFinalDir, *managedGameSolutionTemplateDir, false);
+		sucess = sucess && GenerateProjectVariablesFile();
+
+		if (sucess) {
+			auto & fileStream = *fileManager.CreateFileWriter(*genFileFullPath, EFileWrite::FILEWRITE_None);
+			//TODO: write something meaningfull
+			auto text = FString("generated\n");
+			fileStream << text;
+			fileStream.Close();
+		}
+	}
+
+	return true;
+}
+
+bool CSharpProjectGeneration::GenerateProjectVariablesFile() {
+	FString allLines;
+	FFileHelper::LoadFileToString(allLines, *projectGeneratedVariablesFullFilePath);
+
+	auto projectPath = FPaths::GameDir();
+	auto projectFileName = FPaths::GetBaseFilename(FPaths::GetProjectFilePath());
+
+	//TODO: add optional Constants
+	allLines = allLines.Replace(TEXT("#Constants#"), TEXT(""), ESearchCase::IgnoreCase);
+
+	allLines = allLines.Replace(TEXT("#GamePath#"), *projectPath, ESearchCase::IgnoreCase);
+	allLines = allLines.Replace(TEXT("#GameName#"), *projectFileName, ESearchCase::IgnoreCase);
+
+	FFileHelper::SaveStringToFile(allLines, *projectGeneratedVariablesFullFilePath);
+
+	return true;
+}

--- a/Source/USharp/Private/CSharpProjectGeneration.h
+++ b/Source/USharp/Private/CSharpProjectGeneration.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#if PLATFORM_WINDOWS
+
+//#include "Windows/AllowWindowsPlatformTypes.h"
+
+// Define WIN32_LEAN_AND_MEAN to exclude rarely-used services from windows headers.
+//#define WIN32_LEAN_AND_MEAN
+//#include <windows.h>
+//#include <metahost.h>
+//#pragma comment(lib, "mscoree.lib")
+//
+//#include "Windows/HideWindowsPlatformTypes.h"
+
+#endif
+
+#include "USharpPCH.h"
+
+class CSharpProjectGeneration
+{
+	static bool CopySolutionTemplate();
+	static bool GenerateProjectVariablesFile();
+
+public:
+	static bool GenerateProject();
+};


### PR DESCRIPTION
fix #16 
adding an auto generated managed game solution when plugin loads (editor 95% in 4.20)
it features MSBUILD sdk style project settings.
it works as game or engine plugin type

(currently there is c++ code populating the path properties which may or may not move to the c# side. 
it is to be discussed)
