### PR TITLE
USharp Props File Includes Generated UE4 Module

### DIFF
--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
@@ -26,9 +26,25 @@
     <USharpRunntimeDllPath>$(USharpPluginPath)/Binaries/Managed/UnrealEngine.Runtime.dll</USharpRunntimeDllPath>
   </PropertyGroup>
 
+  <!--Will Only Exist If All Engine And Plugin Modules Are Grouped Together Under One Csproj -->
+  <PropertyGroup>
+    <UE4GenModulesPath>$(USharpPluginPath)/Binaries/Managed/Modules/bin/Debug/UnrealEngine.dll</UE4GenModulesPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="UnrealEngine.Runtime">
       <HintPath>$(USharpRunntimeDllPath)</HintPath>
     </Reference>
   </ItemGroup>
+ 
+  <Choose>
+    <When Condition="Exists('$(UE4GenModulesPath)')">
+      <ItemGroup>
+        <Reference Include="UnrealEngine">
+          <HintPath>$(UE4GenModulesPath)</HintPath>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+
 </Project>


### PR DESCRIPTION
This may cause issues resolving references if this path doesn't exist. I've made it so the reference only gets created if the path exist. If there's an issue with references not resolving, try deleting the vs folder in the managed folder first.