### PR TITLE
Fixes some path for tools that don't set MSBuild's working directory

### DIFF
--- a/ManagedGameSolutionTemplate/Directory.Build.props
+++ b/ManagedGameSolutionTemplate/Directory.Build.props
@@ -3,7 +3,7 @@
     It is picked up by msbuild itself
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectSetup.props" />
+  <Import Project="$(SolutionDir)/USharp.ProjectSetup.props" />
 
-  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectSetup.targets" />
+  <Import Project="$(SolutionDir)/USharp.ProjectSetup.targets" />
 </Project>

--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.props
@@ -1,11 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildStartupDirectory)/USharp.ProjectGeneratedVariables.props" />
+  <Import Project="$(SolutionDir)/USharp.ProjectGeneratedVariables.props" />
 
   <Choose>
     <!--Fallback: This sets up the plugin path when it is used as a game plugin and USharpPluginPath failes to resolve. This sould only happen during development since USharpPluginPath sould always point to the correct path however we may not have ncountered all circumstances yet-->
     <When Condition="!Exists('$(USharpPluginPath)')">
       <PropertyGroup>
-        <USharpPluginPath>$(MSBuildStartupDirectory)/../Plugins/USharp</USharpPluginPath>
+        <USharpPluginPath>$(SolutionDir)/../Plugins/USharp</USharpPluginPath>
       </PropertyGroup>
     </When>
   </Choose>
@@ -15,7 +15,7 @@
   <Choose>
     <When Condition="!Exists('$(USharpPluginPath)')">
       <PropertyGroup>
-        <USharpPluginPath>$(MSBuildStartupDirectory)/../../USharp</USharpPluginPath>
+        <USharpPluginPath>$(SolutionDir)/../../USharp</USharpPluginPath>
       </PropertyGroup>
     </When>
   </Choose>

--- a/ManagedGameSolutionTemplate/USharp.ProjectSetup.targets
+++ b/ManagedGameSolutionTemplate/USharp.ProjectSetup.targets
@@ -2,7 +2,7 @@
   <!-- inject defines and override output path -->
   <PropertyGroup>
     <DefineConstants>$(UE4Defines);$(DefineConstants)</DefineConstants>
-    <OutDir>$(MSBuildStartupDirectory)\Binaries</OutDir>
+    <OutDir>$(SolutionDir)\Binaries</OutDir>
     <OutputPath>$(OutDir)</OutputPath>
     <AssemblyName>$(UE4GameName)-Managed</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
This PR fixes some path issues in the prop files when using other tools (Rider). It would seem VS sets the working directory of MSBuild to the project directory. Not all tools do this. Instead of using `MSBuildStartupDirectory` we use `SolutionDir` instead which seems to be more dependable.

With this, now Rider specifically can be used.