### PR TITLE
Initial support for replicated properties

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Core/FMessage.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Core/FMessage.cs
@@ -9,6 +9,8 @@ namespace UnrealEngine.Runtime
 {
     public static class FMessage
     {
+        public static string LogNet = "LogNet";
+
         public static EAppReturnType OpenDialog(string message)
         {
             return OpenDialog(message, null);

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/CoreUObject/UObject.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/CoreUObject/UObject.cs
@@ -647,13 +647,8 @@ namespace UnrealEngine.Runtime
         /// <summary>
         /// Returns properties that are replicated for the lifetime of the actor channel
         /// </summary>
-        public void GetLifetimeReplicatedProps(List<FLifetimeProperty> lifetimeProps)
+        public virtual void GetLifetimeReplicatedProps(LifetimePropertyRegistry registry)
         {
-            using (TArrayUnsafe<FLifetimeProperty> resultUnsafe = new TArrayUnsafe<FLifetimeProperty>())
-            {
-                Native_UObject.GetLifetimeReplicatedProps(Address, resultUnsafe.Address);
-                lifetimeProps.AddRange(resultUnsafe);
-            }
         }
 
         internal virtual void SetupPlayerInputComponent(IntPtr playerInputComponent)

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/LifetimePropertyRegistry.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/LifetimePropertyRegistry.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+namespace UnrealEngine.Runtime
+{
+    public sealed class LifetimePropertyRegistry
+    {
+        private UObject obj;
+
+        private List<FLifetimeProperty> dest;
+
+        public LifetimePropertyRegistry(UObject obj, List<FLifetimeProperty> dest)
+        {
+            this.obj = obj;
+            this.dest = dest;
+        }
+
+        public void Add(string propertyName)
+        {
+            UProperty property = FindProperty(propertyName);
+
+            for (ushort i = 0; i < property.ArrayDim; i++)
+            {
+                dest.Add(new FLifetimeProperty((ushort) (property.RepIndex + i)));
+            }
+        }
+ 
+        private UProperty FindProperty(string propertyName)
+        {
+            UClass unrealClass = obj.GetClass();
+            UProperty property = unrealClass.FindPropertyByName(new FName(propertyName));
+
+            if (! (FBuild.BuildShipping || FBuild.BuildTest))
+            {
+                if (null == property)
+                {
+                    FMessage.Log(FMessage.LogNet, ELogVerbosity.Fatal, $"Attempt to replicate property '{propertyName}' which does not exist.");
+                }
+                else if (!property.HasAnyPropertyFlags(EPropertyFlags.Net))
+                {
+                    FMessage.Log(FMessage.LogNet, ELogVerbosity.Fatal, $"Attempt to replicate property '{propertyName}' that was not tagged to replicate! Please use 'Replicated' or 'ReplicatedUsing' keyword in the UProperty() declaration.");
+                }
+            }
+
+            return property;
+        }
+    }
+}

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/VTableHacks.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/VTableHacks.cs
@@ -24,17 +24,19 @@ namespace UnrealEngine.Runtime
         delegate void GetLifetimeReplicatedPropsDel(IntPtr address, IntPtr arrayAddress);
         private static void OnGetLifetimeReplicatedProps(IntPtr address, IntPtr arrayAddress)
         {
-            FMessage.Log("TODO: Custom GetLifetimeReplicatedProps");
             UObject obj = GCHelper.Find(address);
-                        
+
             IntPtr original = repProps.GetOriginal(obj);
             Native_VTableHacks.CallOriginal_GetLifetimeReplicatedProps(original, address, arrayAddress);
 
-            //List<FLifetimeProperty> props = new List<FLifetimeProperty>();
-            //obj.GetLifetimeReplicatedProps(props);
-            //
-            //TArrayUnsafeRef<FLifetimeProperty> arrayUnsafe = new TArrayUnsafeRef<FLifetimeProperty>(arrayAddress);
-            //arrayUnsafe.AddRange(props);
+            TArrayUnsafe<FLifetimeProperty> lifetimePropsUnsafe  = new TArrayUnsafe<FLifetimeProperty>(arrayAddress);
+            List<FLifetimeProperty> lifetimeProps = lifetimePropsUnsafe.ToList<FLifetimeProperty>();
+            LifetimePropertyRegistry registry = new LifetimePropertyRegistry(obj, lifetimeProps);
+
+            obj.GetLifetimeReplicatedProps(registry);
+
+            lifetimePropsUnsafe.Clear();
+            lifetimePropsUnsafe.AddRange(lifetimeProps);
         }
 
         private static FunctionRedirect setupPlayerInput;

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/UnrealEngine.Runtime.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Internal\Coroutines\WaitForRealtime.cs" />
     <Compile Include="Internal\EventNotRewrittenException.cs" />
     <Compile Include="Internal\IInterface.cs" />
+    <Compile Include="Internal\LifetimePropertyRegistry.cs" />
     <Compile Include="Internal\ManagedUnrealTypeInfo.Exception.cs" />
     <Compile Include="Internal\ManagedUnrealTypeInfo.Validation.cs" />
     <Compile Include="Internal\ManagedUnrealTypes.Builder.cs" />


### PR DESCRIPTION
This adds support for the most basic of replicated properties. More support will follow.

I'm unsure if there's a better way to implement `OnGetLifetimeReplicatedProps`. I've implemented it like this so that the C# class can see (and potentially modify) the lifetime properties of the super classes.