### PR TITLE
Fixes events on UActorComponent not being called

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/CoreUObject/UObject.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/CoreUObject/UObject.cs
@@ -656,6 +656,16 @@ namespace UnrealEngine.Runtime
             // This is eventually implemented in APawn
         }
 
+        internal virtual void BeginPlayInternal()
+        {
+            // This is eventually implemented in injected classes
+        }
+
+        internal virtual void EndPlayInternal(byte endPlayReason)
+        {
+            // This is eventually implemented in injected classes
+        }
+
         /// <summary>
         /// Looks for a given function name
         /// </summary>

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Classes.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Classes.cs
@@ -74,6 +74,7 @@ namespace UnrealEngine.Runtime
         public static IntPtr UWorld;
         public static IntPtr AActor;
         public static IntPtr APawn;
+        public static IntPtr UActorComponent;
 
         // USharp
         public static IntPtr USharpClass;
@@ -156,6 +157,7 @@ namespace UnrealEngine.Runtime
             UWorld = Native_Classes.UWorld();
             AActor = Native_Classes.AActor();
             APawn = Native_Classes.APawn();
+            UActorComponent = Native_Classes.UActorComponent();
 
             // USharp
             USharpClass = Native_Classes.USharpClass();

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/Exporters/CodeGenerator.FunctionExporter.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/CodeGenerator/Exporters/CodeGenerator.FunctionExporter.cs
@@ -9,8 +9,19 @@ namespace UnrealEngine.Runtime
 {
     public partial class CodeGenerator
     {
+        private static HashSet<string> suppressFunctions = new HashSet<string>()
+        {
+             "/Script/Engine.ActorComponent:ReceiveBeginPlay",
+             "/Script/Engine.ActorComponent:ReceiveEndPlay"
+        };
+
         private bool CanExportFunction(UFunction function, bool isBlueprintType)
         {
+            if (suppressFunctions.Contains(function.PathName))
+            {
+                return false;
+            }
+
             UClass ownerClass = function.GetOuter() as UClass;
             if (ownerClass != null && function.HasAnyFunctionFlags(EFunctionFlags.BlueprintEvent) &&
                 function.GetSuperFunction() == null)

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/InjectedClasses/Engine/ActorComponent_Injected.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/InjectedClasses/Engine/ActorComponent_Injected.cs
@@ -1,9 +1,12 @@
-using System;
+﻿using System;
+using UnrealEngine.Engine;
 using UnrealEngine.Runtime;
 using UnrealEngine.Runtime.Native;
 
 namespace UnrealEngine.Engine
 {
+
+
     public partial class UActorComponent : UObject
     {
         static int PrimaryComponentTick_Offset;
@@ -23,6 +26,24 @@ namespace UnrealEngine.Engine
         static void LoadNativeTypeInjected(IntPtr classAddress)
         {
             PrimaryComponentTick_Offset = NativeReflectionCached.GetPropertyOffset(classAddress, "PrimaryComponentTick");
+        }
+
+        internal override void BeginPlayInternal()
+        {
+            BeginPlay();
+        }
+
+        internal override void EndPlayInternal(byte endPlayReason)
+        {
+            EndPlay((EEndPlayReason) endPlayReason);
+        }
+
+        public virtual void BeginPlay()
+        {
+        }
+
+        public virtual void EndPlay(EEndPlayReason endPlayReason)
+        {
         }
     }
 }

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Native/Internal/Native_Classes.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Native/Internal/Native_Classes.cs
@@ -67,5 +67,6 @@ namespace UnrealEngine.Runtime.Native
         public static Del_StaticClass APawn;
         public static Del_StaticClass USharpClass;
         public static Del_StaticClass USharpStruct;
+        public static Del_StaticClass UActorComponent;
     }
 }

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Native/Native_VTableHacks.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Native/Native_VTableHacks.cs
@@ -13,9 +13,13 @@ namespace UnrealEngine.Runtime.Native
 
         public delegate void Del_CallOriginal_GetLifetimeReplicatedProps(IntPtr originalFunc, IntPtr obj, IntPtr outLifetimeProps);
         public delegate void Del_CallOriginal_SetupPlayerInputComponent(IntPtr originalFunc, IntPtr obj, IntPtr inputComponent);
+        public delegate void Del_CallOriginal_ActorComponentBeginPlay(IntPtr originalFunc, IntPtr obj);
+        public delegate void Del_CallOriginal_ActorComponentEndPlay(IntPtr originalFunc, IntPtr obj, byte endPlayReason);
 
         public static Del_Set_VTableCallback Set_VTableCallback;
         public static Del_CallOriginal_GetLifetimeReplicatedProps CallOriginal_GetLifetimeReplicatedProps;
         public static Del_CallOriginal_SetupPlayerInputComponent CallOriginal_SetupPlayerInputComponent;
+        public static Del_CallOriginal_ActorComponentBeginPlay CallOriginal_ActorComponentBeginPlay;
+        public static Del_CallOriginal_ActorComponentEndPlay CallOriginal_ActorComponentEndPlay;
     }
 }

--- a/Source/USharp/Private/ExportedFunctions/Internal/Export_Classes.h
+++ b/Source/USharp/Private/ExportedFunctions/Internal/Export_Classes.h
@@ -268,6 +268,11 @@ CSEXPORT UClass* CSCONV Export_Classes_APawn()
 	return APawn::StaticClass();
 }
 
+CSEXPORT UClass* CSCONV Export_Classes_UActorComponent()
+{
+    return UActorComponent::StaticClass();
+}
+
 CSEXPORT UClass* CSCONV Export_Classes_USharpClass()
 {
 	return USharpClass::StaticClass();
@@ -337,6 +342,8 @@ CSEXPORT void CSCONV Export_Classes(RegisterFunc registerFunc)
 	REGISTER_FUNC(Export_Classes_UWorld);
 	REGISTER_FUNC(Export_Classes_AActor);
 	REGISTER_FUNC(Export_Classes_APawn);
+	REGISTER_FUNC(Export_Classes_UActorComponent);
+
 
 	// USharp
 	REGISTER_FUNC(Export_Classes_USharpClass);

--- a/Source/USharp/Private/ExportedFunctions/Internal/Export_VTableHacks.h
+++ b/Source/USharp/Private/ExportedFunctions/Internal/Export_VTableHacks.h
@@ -2,6 +2,8 @@
 
 GetLifetimeReplicatedPropsCallbackSig GetLifetimeReplicatedPropsCallback = nullptr;
 SetupPlayerInputComponentCallbackSig SetupPlayerInputComponentCallback = nullptr;
+ActorComponentBeginPlayCallbackSig ActorComponentBeginPlayCallback = nullptr;
+ActorComponentEndPlayCallbackSig ActorComponentEndPlayCallback = nullptr;
 
 TMap<FString, void**> DummyNames;
 CSEXPORT void CSCONV Export_VTableHacks_Set_VTableCallback(const FString& DummyName, void* Callback)
@@ -11,6 +13,8 @@ CSEXPORT void CSCONV Export_VTableHacks_Set_VTableCallback(const FString& DummyN
 		// Use the same names as the class
 		DummyNames.Add(TEXT("DummyRepProps"), (void**)&GetLifetimeReplicatedPropsCallback);
 		DummyNames.Add(TEXT("DummySetupPlayerInput"), (void**)&SetupPlayerInputComponentCallback);
+		DummyNames.Add(TEXT("DummyActorComponentBeginPlay"), (void**)&ActorComponentBeginPlayCallback);
+		DummyNames.Add(TEXT("DummyActorComponentEndPlay"), (void**)&ActorComponentEndPlayCallback);
 	}
 	
 	void*** Element = DummyNames.Find(DummyName);
@@ -33,9 +37,23 @@ CSEXPORT void CSCONV Export_VTableHacks_CallOriginal_SetupPlayerInputComponent(S
 	(Obj->*Func)(PlayerInputComponent);
 }
 
+typedef void (UObject::*ActorComponent_BeginPlayFunc)();
+CSEXPORT void CSCONV Export_VTableHacks_CallOriginal_ActorComponentBeginPlay(ActorComponent_BeginPlayFunc Func, UObject* Obj)
+{
+	(Obj->*Func)();
+}
+
+typedef void (UObject::*ActorComponent_EndPlayFunc)(const EEndPlayReason::Type EndPlayReason);
+CSEXPORT void CSCONV Export_VTableHacks_CallOriginal_ActorComponentEndPlay(ActorComponent_EndPlayFunc Func, UObject* Obj, const EEndPlayReason::Type EndPlayReason)
+{
+	(Obj->*Func)(EndPlayReason);
+}
+
 CSEXPORT void CSCONV Export_VTableHacks(RegisterFunc registerFunc)
 {
 	REGISTER_FUNC(Export_VTableHacks_Set_VTableCallback);
 	REGISTER_FUNC(Export_VTableHacks_CallOriginal_GetLifetimeReplicatedProps);
 	REGISTER_FUNC(Export_VTableHacks_CallOriginal_SetupPlayerInputComponent);
+	REGISTER_FUNC(Export_VTableHacks_CallOriginal_ActorComponentBeginPlay);
+	REGISTER_FUNC(Export_VTableHacks_CallOriginal_ActorComponentEndPlay);
 }

--- a/Source/USharp/Private/VTableHacks.h
+++ b/Source/USharp/Private/VTableHacks.h
@@ -147,3 +147,83 @@ protected:
 		FMsg::Logf("", 0, FName(TEXT("USharp")), ELogVerbosity::Log, TEXT("ADummySetupPlayerInput3-SetupPlayerInputComponent"));
 	}
 };
+
+/////////////////////////////////////////////////////////////////////////////
+// UActorComponent::BeginPlay
+/////////////////////////////////////////////////////////////////////////////
+
+typedef void(*ActorComponentBeginPlayCallbackSig)(UActorComponent* Obj);
+extern ActorComponentBeginPlayCallbackSig ActorComponentBeginPlayCallback;
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentBeginPlay1 : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	virtual void BeginPlay() override
+	{
+		if (ActorComponentBeginPlayCallback != nullptr)
+		{
+			ActorComponentBeginPlayCallback(this);
+		}
+	}
+};
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentBeginPlay2 : public UDummyActorComponentBeginPlay1
+{
+	GENERATED_BODY()
+};
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentBeginPlay3 : public UDummyActorComponentBeginPlay2
+{
+	GENERATED_BODY()
+
+public:
+	virtual void BeginPlay() override
+	{
+		FMsg::Logf("", 0, FName(TEXT("USharp")), ELogVerbosity::Log, TEXT("ADummyActorComponentBeginPlay3-BeginPlay"));
+	}
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// UActorComponent::EndPlay
+/////////////////////////////////////////////////////////////////////////////
+
+typedef void(*ActorComponentEndPlayCallbackSig)(UActorComponent* Obj, const EEndPlayReason::Type EndPlayReason);
+extern ActorComponentEndPlayCallbackSig ActorComponentEndPlayCallback;
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentEndPlay1 : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override
+	{
+		if (ActorComponentEndPlayCallback != nullptr)
+		{
+			ActorComponentEndPlayCallback(this, EndPlayReason);
+		}
+	}
+};
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentEndPlay2 : public UDummyActorComponentEndPlay1
+{
+	GENERATED_BODY()
+};
+
+UCLASS(NotBlueprintable, NotBlueprintType)
+class USHARP_API UDummyActorComponentEndPlay3 : public UDummyActorComponentEndPlay2
+{
+	GENERATED_BODY()
+
+public:
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override
+	{
+		FMsg::Logf("", 0, FName(TEXT("USharp")), ELogVerbosity::Log, TEXT("ADummyActorComponentEndPlay3-EndPlay"));
+	}
+};


### PR DESCRIPTION
The implementations of `ReceiveBeginPlay` and `ReceiveEndPlay` were never called because they are `BlueprintImplementableEvent`'s and are wrapped in a check for `CLASS_CompiledFromBlueprint`.

This PR instead exposes the native `BeginPlay` and `EndPlay` methods.