### PR TITLE
Explicit Cast Fix For VS 2019 Support

### DIFF
--- a/Source/USharp/Private/ExportedFunctions/Export_FGlobals.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_FGlobals.h
@@ -145,7 +145,7 @@ CSEXPORT csbool CSCONV Export_FGlobals_Get_GIsCriticalError()
 
 CSEXPORT void CSCONV Export_FGlobals_Set_GIsCriticalError(csbool value)
 {
-	GIsCriticalError = value;
+	GIsCriticalError = (bool)value;
 }
 
 CSEXPORT csbool CSCONV Export_FGlobals_Get_GIsRunning()

--- a/Source/USharp/Private/ExportedFunctions/Export_FMemory.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_FMemory.h
@@ -117,12 +117,12 @@ CSEXPORT void CSCONV Export_FMemory_EnablePurgatoryTests()
 
 CSEXPORT csbool CSCONV Export_FMemory_PageProtect(void* const Ptr, const SIZE_T Size, const csbool bCanRead, const csbool bCanWrite)
 {
-	return FPlatformMemory::PageProtect(Ptr, Size, bCanRead, bCanWrite);
+	return FPlatformMemory::PageProtect(Ptr, Size, (bool)bCanRead, (bool)bCanWrite);
 }
 
 CSEXPORT FGenericPlatformMemory::FSharedMemoryRegion* CSCONV Export_FMemory_MapNamedSharedMemoryRegion(const FString& Name, csbool bCreate, uint32 AccessMode, SIZE_T Size)
 {
-	return FPlatformMemory::MapNamedSharedMemoryRegion(Name, bCreate, AccessMode, Size);
+	return FPlatformMemory::MapNamedSharedMemoryRegion(Name, (bool)bCreate, AccessMode, Size);
 }
 
 CSEXPORT csbool CSCONV Export_FMemory_UnmapNamedSharedMemoryRegion(FGenericPlatformMemory::FSharedMemoryRegion* MemoryRegion)

--- a/Source/USharp/Private/ExportedFunctions/Export_FSlowTask.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_FSlowTask.h
@@ -1,11 +1,11 @@
 CSEXPORT FSlowTask* CSCONV Export_FSlowTask_New(float InAmountOfWork, const FString& InDefaultMessage, csbool bInEnabled)
 {
-	return new FSlowTask(InAmountOfWork, FText::FromString(InDefaultMessage), bInEnabled);
+	return new FSlowTask(InAmountOfWork, FText::FromString(InDefaultMessage), (bool)bInEnabled);
 }
 
 CSEXPORT FScopedSlowTask* CSCONV Export_FSlowTask_New_FScopedSlowTask(float InAmountOfWork, const FString& InDefaultMessage, csbool bInEnabled)
 {
-	return new FScopedSlowTask(InAmountOfWork, FText::FromString(InDefaultMessage), bInEnabled);
+	return new FScopedSlowTask(InAmountOfWork, FText::FromString(InDefaultMessage), (bool)bInEnabled);
 }
 
 CSEXPORT void CSCONV Export_FSlowTask_Delete(FSlowTask* instance)
@@ -113,12 +113,12 @@ CSEXPORT void CSCONV Export_FSlowTask_Destroy(FSlowTask* instance)
 
 CSEXPORT void CSCONV Export_FSlowTask_MakeDialogDelayed(FSlowTask* instance, float Threshold, csbool bShowCancelButton, csbool bAllowInPIE)
 {
-	instance->MakeDialogDelayed(Threshold, bShowCancelButton, bAllowInPIE);
+	instance->MakeDialogDelayed(Threshold, (bool)bShowCancelButton, (bool)bAllowInPIE);
 }
 
 CSEXPORT void CSCONV Export_FSlowTask_MakeDialog(FSlowTask* instance, csbool bShowCancelButton, csbool bAllowInPIE)
 {
-	instance->MakeDialog(bShowCancelButton, bAllowInPIE);
+	instance->MakeDialog((bool)bShowCancelButton, (bool)bAllowInPIE);
 }
 
 CSEXPORT void CSCONV Export_FSlowTask_EnterProgressFrame(FSlowTask* instance, float ExpectedWorkThisFrame, const FString& Text)

--- a/Source/USharp/Private/ExportedFunctions/Export_FTickFunction.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_FTickFunction.h
@@ -60,7 +60,7 @@ CSEXPORT void CSCONV Export_FTickFunction_RemovePrerequisite(FTickFunction* inst
 
 CSEXPORT void CSCONV Export_FTickFunction_SetPriorityIncludingPrerequisites(FTickFunction* instance, csbool bInHighPriority)
 {
-	instance->SetPriorityIncludingPrerequisites(bInHighPriority);
+	instance->SetPriorityIncludingPrerequisites((bool)bInHighPriority);
 }
 
 CSEXPORT TArray<struct FTickPrerequisite>& CSCONV Export_FTickFunction_GetPrerequisites(FTickFunction* instance)

--- a/Source/USharp/Private/ExportedFunctions/Export_IPluginManager.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_IPluginManager.h
@@ -52,7 +52,7 @@ CSEXPORT void CSCONV Export_IPluginManager_GetDiscoveredPlugins(IPluginManager* 
 
 CSEXPORT void CSCONV Export_IPluginManager_AddPluginSearchPath(IPluginManager* instance, const FString& ExtraDiscoveryPath, csbool bRefresh)
 {
-	instance->AddPluginSearchPath(ExtraDiscoveryPath, bRefresh);
+	instance->AddPluginSearchPath(ExtraDiscoveryPath, (bool)bRefresh);
 }
 
 CSEXPORT void CSCONV Export_IPluginManager_GetPluginsWithPakFile(IPluginManager* instance, TArray<TSharedRef<IPlugin>>& result)

--- a/Source/USharp/Private/ExportedFunctions/Export_UInputComponent.h
+++ b/Source/USharp/Private/ExportedFunctions/Export_UInputComponent.h
@@ -142,7 +142,7 @@ CSEXPORT FInputKeyBinding& CSCONV Export_UInputComponent_BindKey(UInputComponent
 
 CSEXPORT FInputKeyBinding& CSCONV Export_UInputComponent_BindKeyChord(UInputComponent* instance, const FKey& Key, csbool bShift, csbool bCtrl, csbool bAlt, csbool bCmd, uint8 KeyEvent, UObject* Object, UFunction* Func)
 {
-	FInputKeyBinding KB(FInputChord(Key, bShift, bCtrl, bAlt, bCmd), (EInputEvent)KeyEvent);
+	FInputKeyBinding KB(FInputChord(Key, (bool)bShift, (bool)bCtrl, (bool)bAlt, (bool)bCmd), (EInputEvent)KeyEvent);
 	KB.KeyDelegate.BindDelegate(Object, Func->GetFName());
 	instance->KeyBindings.Add(KB);
 	return instance->KeyBindings.Last();


### PR DESCRIPTION
This fixes the compile errors when compiling USharp with Visual Studio 2019.