### PR TITLE
Fixes uninitialized variable when running under Mono

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Core/Math/FRandomStream.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Core/Math/FRandomStream.cs
@@ -111,7 +111,7 @@ namespace UnrealEngine.Runtime
             MutateSeed();
 
             float sRandTemp = 1.0f;
-            float result;
+            float result = 0;
 
             *(int*)&result = (int)(*(int*)&sRandTemp & 0xff800000) | (Seed & 0x007fffff);
 


### PR DESCRIPTION
I was trying out USharp on Linux and compiling the runtime fails with Mono because the variable is uninitialized.