### PR TITLE
minor fixes & improvements

### DIFF
--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/InputCore/FKey.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/InputCore/FKey.cs
@@ -178,7 +178,7 @@ namespace UnrealEngine.InputCore
 
         public static bool operator !=(FKey a, FKey b)
         {
-            return a != b;
+            return !(a == b);
         }
 
         public override bool Equals(object obj)

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Attributes/UMetaAttribute.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/Attributes/UMetaAttribute.cs
@@ -330,37 +330,26 @@ namespace UnrealEngine.Runtime
             Function
         }
 
-        private static void ValidateKeyEnum<TEnum>() where TEnum : struct
-        {
-            if (!typeof(TEnum).IsEnum)
-            {
-                throw new Exception("Using metadata enum functions on a non-enum type! " + typeof(TEnum).FullName);
-            }
-        }
-
         /// <summary>
         /// Returns the group name for the given group enum (just uses typeof(TEnum).Name)
         /// </summary>
-        public static string GetGroup<TEnum>() where TEnum : struct
+        public static string GetGroup<TEnum>() where TEnum : struct, Enum
         {
             return typeof(TEnum).Name;
         }
 
-        public static FName GetKeyName<TEnum>(TEnum key) where TEnum : struct
+        public static FName GetKeyName<TEnum>(TEnum key) where TEnum : struct, Enum
         {
-            ValidateKeyEnum<TEnum>();
             return new FName(key.ToString());
         }
 
-        public static string GetKey<TEnum>(TEnum key) where TEnum : struct
+        public static string GetKey<TEnum>(TEnum key) where TEnum : struct, Enum
         {
-            ValidateKeyEnum<TEnum>();
             return key.ToString();
         }
 
-        public static TEnum ParseKey<TEnum>(string key) where TEnum : struct
+        public static TEnum ParseKey<TEnum>(string key) where TEnum : struct, Enum
         {
-            ValidateKeyEnum<TEnum>();
             TEnum result;
             Enum.TryParse(key, out result);
             return result;
@@ -393,7 +382,7 @@ namespace UnrealEngine.Runtime
             return false;
         }
 
-        public static bool HasMetaData<TEnum>(IntPtr obj, TEnum key) where TEnum : struct
+        public static bool HasMetaData<TEnum>(IntPtr obj, TEnum key) where TEnum : struct, Enum
         {
             return HasMetaData(obj, GetKey(key));
         }
@@ -422,12 +411,12 @@ namespace UnrealEngine.Runtime
             }
         }
 
-        public static void SetMetaData<TEnum, T>(IntPtr obj, TEnum key, T value) where TEnum : struct
+        public static void SetMetaData<TEnum, T>(IntPtr obj, TEnum key, T value) where TEnum : struct, Enum
         {
             SetMetaData(obj, GetKey(key), value);
         }
 
-        public static void RemoveMetaData<TEnum>(IntPtr obj, TEnum key) where TEnum : struct
+        public static void RemoveMetaData<TEnum>(IntPtr obj, TEnum key) where TEnum : struct, Enum
         {
             RemoveMetaData(obj, GetKey(key));
         }
@@ -1345,17 +1334,17 @@ namespace UnrealEngine.Runtime
 
     public static class MetadataExtensions
     {
-        public static bool HasMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static bool HasMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.HasMetaData(UMeta.GetKey(key));
         }        
 
-        public static string GetMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static string GetMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.GetMetaData(UMeta.GetKey(key));
         }
 
-        public static void SetMetaData<TEnum, T>(this UField field, TEnum key, T value) where TEnum : struct
+        public static void SetMetaData<TEnum, T>(this UField field, TEnum key, T value) where TEnum : struct, Enum
         {
             string valueStr = null;
             UClass unrealClass = value as UClass;
@@ -1371,34 +1360,34 @@ namespace UnrealEngine.Runtime
             field.SetMetaData(UMeta.GetKey(key), valueStr);
         }
 
-        public static bool GetBoolMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static bool GetBoolMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.GetBoolMetaData(UMeta.GetKey(key));
         }
 
-        public static int GetIntMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static int GetIntMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.GetIntMetaData(UMeta.GetKey(key));
         }
 
-        public static float GetFloatMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static float GetFloatMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.GetFloatMetaData(UMeta.GetKey(key));
         }
 
-        public static UClass GetClassMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct
+        public static UClass GetClassMetaData<TEnum>(this UField field, TEnum key) where TEnum : struct, Enum
         {
             return field.GetClassMetaData(UMeta.GetKey(key));
         }
 
-        public static bool GetBoolMetaDataHierarchical<TEnum>(this UStruct unrealStruct, TEnum key) where TEnum : struct
+        public static bool GetBoolMetaDataHierarchical<TEnum>(this UStruct unrealStruct, TEnum key) where TEnum : struct, Enum
         {
             return unrealStruct.GetBoolMetaDataHierarchical(new FName(UMeta.GetKey(key)));
         }
 
-        public static bool GeStringMetaDataHierarchical<TEnum>(this UStruct unrealStruct, TEnum key) where TEnum : struct
+        public static bool GetStringMetaDataHierarchical<TEnum>(this UStruct unrealStruct, TEnum key, ref string outValue) where TEnum : struct, Enum
         {
-            return unrealStruct.GeStringMetaDataHierarchical(new FName(UMeta.GetKey(key)));
+            return unrealStruct.GetStringMetaDataHierarchical(new FName(UMeta.GetKey(key)), ref outValue);
         }
     }
 }

--- a/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/WorldTimeHelper.cs
+++ b/Managed/UnrealEngine.Runtime/UnrealEngine.Runtime/Internal/WorldTimeHelper.cs
@@ -131,7 +131,7 @@ namespace UnrealEngine.Runtime
 
         public static TimeSpan GetUnpausedTimeChecked(IntPtr world)
         {
-            return GetUnpausedTimeChecked(GetWorldChecked(world));
+            return GetUnpausedTime(GetWorldChecked(world));
         }
 
         public static TimeSpan GetUnpausedTime(IntPtr world)
@@ -163,7 +163,7 @@ namespace UnrealEngine.Runtime
 
         public static float GetUnpausedTimeSecondsChecked(IntPtr world)
         {
-            return GetUnpausedTimeSecondsChecked(GetWorldChecked(world));
+            return GetUnpausedTimeSeconds(GetWorldChecked(world));
         }
 
         public static float GetUnpausedTimeSeconds(IntPtr world)


### PR DESCRIPTION
- now using native c#7 enum type check for generic `where` clauses in UMetaAttribute.cs
- fixed typo: MetadataExtensions.GeStringMetaDataHierarchical (missing "t" in Get) lead to an infinite recursion
- added `ref string` parameter to MetadataExtensions.GetStringMetaDataHierarchical (would've been pretty useless without)
- fixed infinite recursion in "!=" operator overload of FKey
- fixed 2 copy-paste errors in WorldTimeHelper.GetUnpausedTimeSecondsChecked and GetUnpausedTimeChecked (infinite recursion again)