### PR TITLE
Adds missing TextProperty include

### DIFF
--- a/Source/USharp/Private/ExportedFunctions/Internal/HotReload/SharpHotReloadClassReinstancer.cpp
+++ b/Source/USharp/Private/ExportedFunctions/Internal/HotReload/SharpHotReloadClassReinstancer.cpp
@@ -5,6 +5,7 @@
 #include "UObject/UObjectHash.h"
 #include "UObject/UObjectIterator.h"
 #include "UObject/Package.h"
+#include "UObject/TextProperty.h"
 #include "Serialization/ArchiveReplaceObjectRef.h"
 #include "BlueprintCompilationManager.h"
 #if WITH_ENGINE


### PR DESCRIPTION
UTextProperty include was missing when building the plugin against an installed version of UE.